### PR TITLE
Fix conflicting keyboard shortcut combination on Windows and Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/
 
 | Command                                 | Hotkey (PC)       | Hotkey (Apple)       |
 | --------------------------------------- | ----------------- | -------------------- |
-| Open Zoho CRM Account Module in new tab | `alt + shift + a` | `option + shift + a` |
+| Open Zoho CRM Account Module in new tab | `alt + shift + o` | `option + shift + a` |
 | Open Zoho CRM Contact Module in new tab | `alt + shift + c` | `option + shift + c` |
 | Open Zoho CRM Deal Module in new tab    | `alt + shift + d` | `option + shift + d` |
 | Open Zoho CRM Lead Module in new tab    | `alt + shift + l` | `option + shift + l` |

--- a/README.md
+++ b/README.md
@@ -1,12 +1,4 @@
-<<<<<<< HEAD
-
-# Hotkeys for Zoho CRM as Chrome Browser Extension
-
-=======
-
 # Better Hotkeys for Zoho CRM - Chrome Browser Extension
-
-> > > > > > > 0970161 (docs: Apply the correct title of the chrome extension everywhere)
 
 ## Development
 

--- a/chrome-web-store/CHROME_WEB_STORE_CONFIGURATION.md
+++ b/chrome-web-store/CHROME_WEB_STORE_CONFIGURATION.md
@@ -26,13 +26,13 @@ Easy keyboard hotkeys for navigating the Zoho CRM menu bar
 Create new, edit, save and delete Zoho CRM records at the speed of light
 - New Zoho record = `n`
 - Edit Zoho record = `e`
-- Save Zoho record = `alt + s` on PC / `option + s` on Apple
+- Save Zoho record = `alt + s` on Win and Linux / `option + s` on Apple
 - etc.
 
 Quickly open Zoho CRM modules in a new tab from anywhere
-- Open Zoho Account Module = `alt + shift + o` on PC / `option + shift + a` on Apple
-- Open Zoho Contact Module = `alt + shift + c` on PC / `option + shift + c` on Apple
-- Open Zoho Deal Module = `alt + shift + d` on PC / `option + shift + d` on Apple
+- Open Zoho Account Module = `alt + shift + o` on Win and Linux / `option + shift + a` on Apple
+- Open Zoho Contact Module = `alt + shift + c` on Win and Linux / `option + shift + c` on Apple
+- Open Zoho Deal Module = `alt + shift + d` on Win and Linux / `option + shift + d` on Apple
 - etc.
 
 COMING SOON ...

--- a/chrome-web-store/CHROME_WEB_STORE_CONFIGURATION.md
+++ b/chrome-web-store/CHROME_WEB_STORE_CONFIGURATION.md
@@ -30,7 +30,7 @@ Create new, edit, save and delete Zoho CRM records at the speed of light
 - etc.
 
 Quickly open Zoho CRM modules in a new tab from anywhere
-- Open Zoho Account Module = `alt + shift + a` on PC / `option + shift + a` on Apple
+- Open Zoho Account Module = `alt + shift + o` on PC / `option + shift + a` on Apple
 - Open Zoho Contact Module = `alt + shift + c` on PC / `option + shift + c` on Apple
 - Open Zoho Deal Module = `alt + shift + d` on PC / `option + shift + d` on Apple
 - etc.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-hotkeys-for-zoho-crm",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Better Hotkeys for Zoho CRM - Chrome Browser Extension",
   "scripts": {
     "build": "NODE_ENV=\"production\" node esbuild.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-hotkeys-for-zoho-crm",
-  "version": "1.0",
+  "version": "1.0.1",
   "description": "Better Hotkeys for Zoho CRM - Chrome Browser Extension",
   "scripts": {
     "build": "NODE_ENV=\"production\" node esbuild.js",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -29,33 +29,34 @@
     }
   ],
   "commands": {
-    "zoho-leads-open": {
-      "suggested_key": {
-        "default": "Alt+Shift+L",
-        "mac": "Alt+Shift+L"
-      },
-      "description": "Open Leads module"
-    },
-    "zoho-deals-open": {
-      "suggested_key": {
-        "default": "Alt+Shift+D",
-        "mac": "Alt+Shift+D"
-      },
-      "description": "Open Deals module"
-    },
     "zoho-accounts-open": {
+      "description": "Open Accounts module",
       "suggested_key": {
         "default": "Alt+Shift+A",
-        "mac": "Alt+Shift+A"
-      },
-      "description": "Open Accounts module"
+        "mac": "Alt+Shift+A",
+        "windows": "Alt+Shift+O"
+      }
     },
     "zoho-contacts-open": {
+      "description": "Open Contacts module",
       "suggested_key": {
         "default": "Alt+Shift+C",
         "mac": "Alt+Shift+C"
-      },
-      "description": "Open Contacts module"
+      }
+    },
+    "zoho-deals-open": {
+      "description": "Open Deals module",
+      "suggested_key": {
+        "default": "Alt+Shift+D",
+        "mac": "Alt+Shift+D"
+      }
+    },
+    "zoho-leads-open": {
+      "description": "Open Leads module",
+      "suggested_key": {
+        "default": "Alt+Shift+L",
+        "mac": "Alt+Shift+L"
+      }
     }
   },
   "permissions": ["storage"]

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -34,6 +34,7 @@
       "suggested_key": {
         "default": "Alt+Shift+A",
         "mac": "Alt+Shift+A",
+        "linux": "Alt+Shift+O",
         "windows": "Alt+Shift+O"
       }
     },

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Better Hotkeys For Zoho CRM",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "manifest_version": 3,
   "background": {
     "service_worker": "build/background.js"

--- a/src/Popup/App.tsx
+++ b/src/Popup/App.tsx
@@ -385,16 +385,7 @@ export default function App() {
                   <kbd>Alt</kbd> <kbd>⇧ shift</kbd> <kbd>a</kbd>
                 </td>
                 <td>
-                  <kbd>⌥ option</kbd> <kbd>⇧ shift</kbd> <kbd>a</kbd>
-                </td>
-              </tr>
-              <tr>
-                <td>Open Deals Module (global)</td>
-                <td>
-                  <kbd>Alt</kbd> <kbd>⇧ shift</kbd> <kbd>d</kbd>
-                </td>
-                <td>
-                  <kbd>⌥ option</kbd> <kbd>⇧ shift</kbd> <kbd>d</kbd>
+                  <kbd>⌥ option</kbd> <kbd>⇧ shift</kbd> <kbd>o</kbd>
                 </td>
               </tr>
               <tr>
@@ -404,6 +395,15 @@ export default function App() {
                 </td>
                 <td>
                   <kbd>⌥ option</kbd> <kbd>⇧ shift</kbd> <kbd>c</kbd>
+                </td>
+              </tr>
+              <tr>
+                <td>Open Deals Module (global)</td>
+                <td>
+                  <kbd>Alt</kbd> <kbd>⇧ shift</kbd> <kbd>d</kbd>
+                </td>
+                <td>
+                  <kbd>⌥ option</kbd> <kbd>⇧ shift</kbd> <kbd>d</kbd>
                 </td>
               </tr>
               <tr>

--- a/src/Popup/App.tsx
+++ b/src/Popup/App.tsx
@@ -176,7 +176,7 @@ export default function App() {
             <thead>
               <tr>
                 <th>Function</th>
-                <th>Hotkey PC</th>
+                <th>Hotkey PC (Win / Linux)</th>
                 <th>Hotkey Mac</th>
               </tr>
             </thead>
@@ -197,7 +197,7 @@ export default function App() {
             <thead>
               <tr>
                 <th>Function</th>
-                <th>Hotkey PC</th>
+                <th>Hotkey PC (Win / Linux)</th>
                 <th>Hotkey Mac</th>
               </tr>
             </thead>
@@ -308,7 +308,7 @@ export default function App() {
             <thead>
               <tr>
                 <th>Function</th>
-                <th>Hotkey PC</th>
+                <th>Hotkey PC (Win / Linux)</th>
                 <th>Hotkey Mac</th>
               </tr>
             </thead>
@@ -374,7 +374,7 @@ export default function App() {
             <thead>
               <tr>
                 <th>Function</th>
-                <th>Hotkey PC</th>
+                <th>Hotkey PC (Win / Linux)</th>
                 <th>Hotkey Mac</th>
               </tr>
             </thead>


### PR DESCRIPTION
## Further Notes

- After testing the extension on windows and linux, we identified that one of the default keyboard shortcut combination `Alt+Shift+A` was already taken, see https://support.google.com/chrome/answer/157179#zippy=%2Cgoogle-chrome-feature-shortcuts
- This leads to a conflicting keyboard shortcut when installing the chrome extension

## New Features / Enhancements

When installing the chrome extension in Win and Linux, the default keyboard shortcut for opening the accounts module is `Alt+Shift+O`

- [x] Tested on Win11 Chrome
- [x] Tested on Linux Chromium

## After Merge Checklist
