### PR TITLE
Add default value for Zoho CRM system (crm. / crmsandbox.)

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Better Hotkeys For Zoho CRM",
-  "version": "1.0",
+  "version": "1.0.1",
   "manifest_version": 3,
   "background": {
     "service_worker": "build/background.js"

--- a/src/Popup/App.tsx
+++ b/src/Popup/App.tsx
@@ -20,7 +20,9 @@ export default function App() {
     });
 
     chrome.storage.local.get("zohoCRMSystem", (result) => {
-      setZohoCRMSystem(result.zohoCRMSystem);
+      const zohoCRMSystem = result.zohoCRMSystem;
+      if (!zohoCRMSystem) saveData("zohoCRMSystem", "crm");
+      setZohoCRMSystem(zohoCRMSystem);
     });
   }, []);
 

--- a/src/services/UrlService.ts
+++ b/src/services/UrlService.ts
@@ -8,8 +8,8 @@ export default class UrlService {
     const zohoLocation =
       (await chrome.storage.local.get("location")).location || "com";
     const zohoOrgId = (await chrome.storage.local.get("zohoId")).zohoId;
-    const zohoCRMSystem = (await chrome.storage.local.get("zohoCRMSystem"))
-      .zohoCRMSystem;
+    const zohoCRMSystem =
+      (await chrome.storage.local.get("zohoCRMSystem")).zohoCRMSystem || "crm";
 
     if (!zohoOrgId) {
       return `https://${zohoCRMSystem}.zoho.${zohoLocation}/crm`;

--- a/src/services/UrlService.ts
+++ b/src/services/UrlService.ts
@@ -7,9 +7,9 @@ export default class UrlService {
   public static getZohoUrl = async (): Promise<string> => {
     const zohoLocation =
       (await chrome.storage.local.get("location")).location || "com";
-    const zohoOrgId = (await chrome.storage.local.get("zohoId")).zohoId;
+    const zohoOrgId = (await chrome.storage.local.get("zohoId"))?.zohoId;
     const zohoCRMSystem =
-      (await chrome.storage.local.get("zohoCRMSystem")).zohoCRMSystem || "crm";
+      (await chrome.storage.local.get("zohoCRMSystem"))?.zohoCRMSystem || "crm";
 
     if (!zohoOrgId) {
       return `https://${zohoCRMSystem}.zoho.${zohoLocation}/crm`;


### PR DESCRIPTION
## Further Notes

- Currently, there is no default for the Zoho CRM instance => this means that you are not able to start right away after you install the extension
- E.g. when using ht hotkey `Alt+Shift+a`, you would land on https://undefined.zoho.com/ which is not vali

## New Features / Enhancements

- [x] Added default config for main Zoho CRM instance `https://crm.zoho.com`
- [x] After the installation of the extension, it is now possible to use the hotkeys `Alt+Shift+a` to open the Accounts Module in the Zoho CRM instance `https://www.zoho.com/crm/tab/Accounts`

## After Merge Checklist

- [ ] Update release of plugin
